### PR TITLE
Add RSVP flow

### DIFF
--- a/lib/rsvp.ts
+++ b/lib/rsvp.ts
@@ -1,0 +1,20 @@
+import { supabase } from './supabase';
+
+/**
+ * Save an RSVP to Supabase for a given profile and event date.
+ * @param profileId - The profile ID of the user RSVPing
+ * @param eventDate - ISO date string of the event (YYYY-MM-DD)
+ * @returns True on success, false on error
+ */
+export async function saveRsvp(profileId: string, eventDate: string): Promise<boolean> {
+  const { error } = await supabase
+    .from('rsvps')
+    .insert([{ profile_id: profileId, event_date: eventDate }]);
+
+  if (error) {
+    console.error('Failed to save RSVP:', error.message);
+    return false;
+  }
+
+  return true;
+}

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -10,3 +10,12 @@ export type Profile = {
   experienceLevel: 'none' | 'beginner' | 'intermediate' | 'advanced' | null;
   created_at: string;
 };
+/**
+ * RSVP type reflects the 'rsvps' table schema in Supabase.
+ */
+export type Rsvp = {
+  id: string;
+  profile_id: string;
+  event_date: string;
+  created_at: string;
+};


### PR DESCRIPTION
## Summary
- store rsvps in Supabase via new helper
- ask user to RSVP after profile onboarding
- remember RSVP answer in localStorage
- include RSVP type in Supabase types

## Testing
- `npm install`
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_684c1a4437f4832880ce0c0bdf16317b