### PR TITLE
Add events calendar and dynamic RSVP flow

### DIFF
--- a/app/events/[id]/edit/page.tsx
+++ b/app/events/[id]/edit/page.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useState, useEffect } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import { updateEvent, getEventById } from '@/lib/events';
+
+export default function EditEventPage() {
+  const router = useRouter();
+  const params = useParams();
+  const eventId = Array.isArray(params?.id) ? params.id[0] : params?.id;
+
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [dateTime, setDateTime] = useState('');
+  const [location, setLocation] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!eventId) return;
+    (async () => {
+      const event = await getEventById(eventId as string);
+      if (event) {
+        setTitle(event.title || '');
+        setDescription(event.description || '');
+        setDateTime(event.event_datetime ? event.event_datetime.substring(0,16) : '');
+        setLocation(event.location || '');
+      }
+      setLoading(false);
+    })();
+  }, [eventId]);
+
+  if (!eventId) return <div>Error: No event ID provided.</div>;
+  if (loading) return <div>Loading event...</div>;
+
+  return (
+    <div className="max-w-md mx-auto">
+      <h2 className="text-2xl font-bold mb-4">Edit Event</h2>
+      <form
+        onSubmit={async e => {
+          e.preventDefault();
+          setSaving(true);
+          setMessage(null);
+          const success = await updateEvent(eventId as string, {
+            title: title.trim(),
+            description: description.trim() || null,
+            event_datetime: dateTime,
+            location: location.trim() || null,
+          });
+          setSaving(false);
+          if (success) {
+            setMessage('✅ Event updated successfully!');
+            setTimeout(() => router.push('/events'), 1000);
+          } else {
+            setMessage('❌ Failed to update event.');
+          }
+        }}
+      >
+        <div className="mb-3">
+          <label className="block font-medium mb-1">Title</label>
+          <input
+            type="text"
+            className="w-full border px-3 py-2"
+            value={title}
+            onChange={e => setTitle(e.target.value)}
+            required
+          />
+        </div>
+        <div className="mb-3">
+          <label className="block font-medium mb-1">Description</label>
+          <textarea
+            className="w-full border px-3 py-2"
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+            rows={3}
+          />
+        </div>
+        <div className="mb-3">
+          <label className="block font-medium mb-1">Date &amp; Time</label>
+          <input
+            type="datetime-local"
+            className="w-full border px-3 py-2"
+            value={dateTime}
+            onChange={e => setDateTime(e.target.value)}
+            required
+          />
+        </div>
+        <div className="mb-3">
+          <label className="block font-medium mb-1">Location</label>
+          <input
+            type="text"
+            className="w-full border px-3 py-2"
+            value={location}
+            onChange={e => setLocation(e.target.value)}
+          />
+        </div>
+        <button
+          type="submit"
+          className="bg-blue-600 text-white px-4 py-2 rounded"
+          disabled={saving}
+        >
+          {saving ? 'Updating...' : 'Update Event'}
+        </button>
+        {message && <p className="mt-2">{message}</p>}
+      </form>
+    </div>
+  );
+}

--- a/app/events/new/page.tsx
+++ b/app/events/new/page.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { createEvent } from '@/lib/events';
+
+export default function NewEventPage() {
+  const router = useRouter();
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [dateTime, setDateTime] = useState('');
+  const [location, setLocation] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  return (
+    <div className="max-w-md mx-auto">
+      <h2 className="text-2xl font-bold mb-4">Add New Event</h2>
+      <form
+        onSubmit={async e => {
+          e.preventDefault();
+          setSaving(true);
+          setMessage(null);
+          const success = await createEvent({
+            title: title.trim(),
+            description: description.trim() || null,
+            event_datetime: dateTime,
+            location: location.trim() || null,
+          });
+          setSaving(false);
+          if (success) {
+            setMessage('✅ Event created successfully!');
+            setTimeout(() => router.push('/events'), 1000);
+          } else {
+            setMessage('❌ Failed to create event. Check console for errors.');
+          }
+        }}
+      >
+        <div className="mb-3">
+          <label className="block font-medium mb-1">Title</label>
+          <input
+            type="text"
+            className="w-full border px-3 py-2"
+            value={title}
+            onChange={e => setTitle(e.target.value)}
+            required
+          />
+        </div>
+        <div className="mb-3">
+          <label className="block font-medium mb-1">Description</label>
+          <textarea
+            className="w-full border px-3 py-2"
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+            rows={3}
+          />
+        </div>
+        <div className="mb-3">
+          <label className="block font-medium mb-1">Date &amp; Time</label>
+          <input
+            type="datetime-local"
+            className="w-full border px-3 py-2"
+            value={dateTime}
+            onChange={e => setDateTime(e.target.value)}
+            required
+          />
+        </div>
+        <div className="mb-3">
+          <label className="block font-medium mb-1">Location</label>
+          <input
+            type="text"
+            className="w-full border px-3 py-2"
+            value={location}
+            onChange={e => setLocation(e.target.value)}
+          />
+        </div>
+        <button
+          type="submit"
+          className="bg-blue-600 text-white px-4 py-2 rounded"
+          disabled={saving}
+        >
+          {saving ? 'Saving...' : 'Create Event'}
+        </button>
+        {message && <p className="mt-2">{message}</p>}
+      </form>
+    </div>
+  );
+}

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import { getUpcomingEvents } from '@/lib/events';
+import { saveRsvp } from '@/lib/rsvp';
+import type { Event } from '@/types/supabase';
+
+export default function EventsPage() {
+  const [events, setEvents] = useState<Event[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [rsvpMessage, setRsvpMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const data = await getUpcomingEvents();
+      setEvents(data);
+      setLoading(false);
+    })();
+  }, []);
+
+  if (loading) return <div>Loading events...</div>;
+  if (!loading && events.length === 0) return <div><em>No upcoming events.</em></div>;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-center">
+        <h2 className="text-2xl font-bold mb-4">Upcoming Events</h2>
+        <a href="/events/new" className="text-white bg-green-600 px-3 py-2 rounded">+ Add New Event</a>
+      </div>
+      <ul className="space-y-4">
+        {events.map(event => (
+          <li key={event.id} className="border p-4 rounded">
+            <h3 className="text-xl font-semibold">{event.title}</h3>
+            <p><strong>Date:</strong> {new Date(event.event_datetime).toLocaleString()}</p>
+            {event.location && <p><strong>Location:</strong> {event.location}</p>}
+            {event.description && <p>{event.description}</p>}
+            <div className="mt-2 space-x-4">
+              <button
+                className="px-4 py-2 bg-blue-600 text-white rounded"
+                onClick={async () => {
+                  const profileId = localStorage.getItem('profile_id');
+                  if (!profileId) {
+                    setRsvpMessage('Please complete the onboarding chat to create a profile before RSVPing.');
+                    return;
+                  }
+                  const success = await saveRsvp(profileId, event.id);
+                  if (success) {
+                    setRsvpMessage(`✅ You have RSVPed for "${event.title}"!`);
+                  } else {
+                    setRsvpMessage('❌ Failed to RSVP. Please try again.');
+                  }
+                }}
+              >
+                RSVP
+              </button>
+              <a href={`/events/${event.id}/edit`} className="text-sm text-blue-600 underline">Edit</a>
+            </div>
+          </li>
+        ))}
+      </ul>
+      {rsvpMessage && <div className="mt-4 text-center">{rsvpMessage}</div>}
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import Link from 'next/link';
 import "./globals.css";
 
 const geistSans = Geist({
@@ -26,8 +27,12 @@ export default function RootLayout({
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} flex flex-col min-h-screen antialiased`}>
         <header className="bg-white shadow">
-          <div className="container mx-auto px-4 py-4">
+          <div className="container mx-auto px-4 py-4 flex justify-between items-center">
             <h1 className="text-2xl font-bold text-pink-600">Gay-I Club Concierge</h1>
+            <nav className="space-x-4">
+              <Link href="/" className="text-sm">Home</Link>
+              <Link href="/events" className="text-sm">Events</Link>
+            </nav>
           </div>
         </header>
         <main className="container mx-auto px-4 py-8 flex-1">{children}</main>

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -1,0 +1,68 @@
+import { supabase } from './supabase';
+import { Event } from '@/types/supabase';
+
+// Fetch upcoming events sorted by date
+export async function getUpcomingEvents(): Promise<Event[]> {
+  const { data, error } = await supabase
+    .from('events')
+    .select('*')
+    .gte('event_datetime', new Date().toISOString())
+    .order('event_datetime', { ascending: true });
+  if (error) {
+    console.error('Error fetching events:', error.message);
+    return [];
+  }
+  return data || [];
+}
+
+// Insert a new event
+export async function createEvent(newEvent: {
+  title: string;
+  description?: string | null;
+  event_datetime: string;
+  location?: string | null;
+}): Promise<boolean> {
+  const { error } = await supabase.from('events').insert([
+    {
+      title: newEvent.title,
+      description: newEvent.description ?? null,
+      event_datetime: newEvent.event_datetime,
+      location: newEvent.location ?? null,
+    },
+  ]);
+  if (error) {
+    console.error('Failed to insert event:', error.message);
+    return false;
+  }
+  return true;
+}
+
+// Update an existing event by ID
+export async function updateEvent(
+  eventId: string,
+  updates: Partial<Event>
+): Promise<boolean> {
+  const { error } = await supabase
+    .from('events')
+    .update(updates)
+    .eq('id', eventId);
+  if (error) {
+    console.error('Failed to update event:', error.message);
+    return false;
+  }
+  return true;
+}
+
+// Get a single event by its ID
+export async function getEventById(id: string): Promise<Event | null> {
+  const { data, error } = await supabase
+    .from('events')
+    .select('*')
+    .eq('id', id)
+    .single();
+  if (error) {
+    console.error('Error fetching event:', error.message);
+    return null;
+  }
+  return data as Event;
+}

--- a/lib/rsvp.ts
+++ b/lib/rsvp.ts
@@ -1,15 +1,15 @@
 import { supabase } from './supabase';
 
 /**
- * Save an RSVP to Supabase for a given profile and event date.
+ * Save an RSVP to Supabase for a given profile and event.
  * @param profileId - The profile ID of the user RSVPing
- * @param eventDate - ISO date string of the event (YYYY-MM-DD)
+ * @param eventId - The ID of the event being RSVPed to
  * @returns True on success, false on error
  */
-export async function saveRsvp(profileId: string, eventDate: string): Promise<boolean> {
+export async function saveRsvp(profileId: string, eventId: string): Promise<boolean> {
   const { error } = await supabase
     .from('rsvps')
-    .insert([{ profile_id: profileId, event_date: eventDate }]);
+    .insert([{ profile_id: profileId, event_id: eventId }]);
 
   if (error) {
     console.error('Failed to save RSVP:', error.message);

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -10,12 +10,25 @@ export type Profile = {
   experienceLevel: 'none' | 'beginner' | 'intermediate' | 'advanced' | null;
   created_at: string;
 };
+
+/**
+ * Event type reflects the 'events' table schema in Supabase.
+ */
+export type Event = {
+  id: string;
+  title: string;
+  description: string | null;
+  event_datetime: string;
+  location: string | null;
+  created_at: string;
+};
 /**
  * RSVP type reflects the 'rsvps' table schema in Supabase.
  */
 export type Rsvp = {
   id: string;
   profile_id: string;
-  event_date: string;
+  event_id: string;
+  event_date?: string;
   created_at: string;
 };


### PR DESCRIPTION
## Summary
- define `Event` type and update `Rsvp` to use `event_id`
- create Supabase event helpers
- add pages for listing, creating and editing events
- refactor chat RSVP prompt to be dynamic
- update RSVP utilities and navigation

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68555713074083289628a194d95faac6