### PR TITLE
Add deletion button for events

### DIFF
--- a/app/events/[id]/edit/page.tsx
+++ b/app/events/[id]/edit/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { useRouter, useParams } from 'next/navigation';
-import { updateEvent, getEventById } from '@/lib/events';
+import { updateEvent, getEventById, deleteEvent } from '@/lib/events';
 
 export default function EditEventPage() {
   const router = useRouter();
@@ -101,6 +101,25 @@ export default function EditEventPage() {
           disabled={saving}
         >
           {saving ? 'Updating...' : 'Update Event'}
+        </button>
+        <button
+          type="button"
+          className="bg-red-600 text-white px-4 py-2 rounded ml-2"
+          onClick={async () => {
+            if (!confirm('Delete this event?')) return;
+            setSaving(true);
+            setMessage(null);
+            const success = await deleteEvent(eventId as string);
+            setSaving(false);
+            if (success) {
+              setMessage('✅ Event deleted successfully!');
+              setTimeout(() => router.push('/events'), 1000);
+            } else {
+              setMessage('❌ Failed to delete event.');
+            }
+          }}
+        >
+          Delete Event
         </button>
         {message && <p className="mt-2">{message}</p>}
       </form>

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -66,3 +66,13 @@ export async function getEventById(id: string): Promise<Event | null> {
   }
   return data as Event;
 }
+
+// Delete an event by ID
+export async function deleteEvent(eventId: string): Promise<boolean> {
+  const { error } = await supabase.from('events').delete().eq('id', eventId);
+  if (error) {
+    console.error('Failed to delete event:', error.message);
+    return false;
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary
- allow events to be deleted via `deleteEvent`
- add "Delete Event" button on the edit event page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68555db67afc83289448456c5f0a3b65