### PR TITLE
Add invite feature and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
 ## Getting Started
+## Features
+
+- RSVP only allowed after completing onboarding.
+- `/invite` page lets you generate a short invite and copy it.
 
 First, run the development server:
 

--- a/app/api/invite/route.ts
+++ b/app/api/invite/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+
+export const runtime = "edge";
+
+/**
+ * POST /api/invite
+ * Generates a short quirky invite using OpenAI Chat Completion.
+ * Optional body: { style?: string } to add extra style hints to the prompt.
+ */
+export async function POST(req: Request) {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json({ error: "Missing OpenAI API key" }, { status: 500 });
+  }
+
+  let style = "";
+  try {
+    const body = await req.json();
+    style = body?.style ? String(body.style) : "";
+  } catch {
+    // ignore invalid json / empty body
+  }
+
+  const prompt =
+    "Write a short quirky invite (≤ 3 sentences) that includes the URL https://gayiclub.com." +
+    (style ? ` ${style}` : "");
+
+  const apiRes = await fetch("https://api.openai.com/v1/chat/completions", {
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    method: "POST",
+    body: JSON.stringify({
+      model: "gpt-4o",
+      messages: [{ role: "user", content: prompt }],
+    }),
+  });
+
+  if (!apiRes.ok) {
+    const error = await apiRes.text();
+    console.error("OpenAI error", error);
+    return NextResponse.json(
+      { error: "Couldn't generate invite, please try again." },
+      { status: 500 }
+    );
+  }
+
+  const data = await apiRes.json();
+  const message = data.choices?.[0]?.message?.content?.trim();
+  return NextResponse.json({ message });
+}

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -9,6 +9,7 @@ export default function EventsPage() {
   const [events, setEvents] = useState<Event[]>([]);
   const [loading, setLoading] = useState(true);
   const [rsvpMessage, setRsvpMessage] = useState<string | null>(null);
+  const [rsvpedEvents, setRsvpedEvents] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     (async () => {
@@ -35,24 +36,29 @@ export default function EventsPage() {
             {event.location && <p><strong>Location:</strong> {event.location}</p>}
             {event.description && <p>{event.description}</p>}
             <div className="mt-2 space-x-4">
-              <button
-                className="px-4 py-2 bg-blue-600 text-white rounded"
-                onClick={async () => {
-                  const profileId = localStorage.getItem('profile_id');
-                  if (!profileId) {
-                    setRsvpMessage('Please complete the onboarding chat to create a profile before RSVPing.');
-                    return;
-                  }
-                  const success = await saveRsvp(profileId, event.id);
-                  if (success) {
-                    setRsvpMessage(`✅ You have RSVPed for "${event.title}"!`);
-                  } else {
-                    setRsvpMessage('❌ Failed to RSVP. Please try again.');
-                  }
-                }}
-              >
-                RSVP
-              </button>
+              {rsvpedEvents.has(event.id) ? (
+                <span className="text-green-600 font-semibold">✅ RSVPed</span>
+              ) : (
+                <button
+                  className="px-4 py-2 bg-blue-600 text-white rounded"
+                  onClick={async () => {
+                    const profileId = localStorage.getItem('profile_id');
+                    if (!profileId) {
+                      setRsvpMessage('Please complete onboarding to create a profile before RSVPing.');
+                      return;
+                    }
+                    const success = await saveRsvp(profileId, event.id);
+                    if (success) {
+                      setRsvpMessage(`✅ You have RSVPed for "${event.title}"!`);
+                      setRsvpedEvents(prev => new Set(prev).add(event.id));
+                    } else {
+                      setRsvpMessage('❌ Failed to RSVP. Please try again.');
+                    }
+                  }}
+                >
+                  RSVP
+                </button>
+              )}
               <a href={`/events/${event.id}/edit`} className="text-sm text-blue-600 underline">Edit</a>
             </div>
           </li>

--- a/app/invite/page.tsx
+++ b/app/invite/page.tsx
@@ -1,0 +1,10 @@
+import InviteCard from '@/components/InviteCard';
+
+export default function InvitePage() {
+  return (
+    <div className="max-w-md mx-auto">
+      <h2 className="text-2xl font-bold mb-4">Generate an Invite</h2>
+      <InviteCard />
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -32,6 +32,7 @@ export default function RootLayout({
             <nav className="space-x-4">
               <Link href="/" className="text-sm">Home</Link>
               <Link href="/events" className="text-sm">Events</Link>
+              <Link href="/invite" className="text-sm">Invite</Link>
             </nav>
           </div>
         </header>

--- a/components/InviteCard.tsx
+++ b/components/InviteCard.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+
+/**
+ * InviteCard component allows users to generate a short invite message
+ * using the /api/invite endpoint and copy it to their clipboard.
+ */
+export default function InviteCard() {
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const generateInvite = async () => {
+    setLoading(true);
+    setMessage(null);
+    setCopied(false);
+    const res = await fetch("/api/invite", { method: "POST" });
+    if (!res.ok) {
+      setMessage(null);
+      setLoading(false);
+      setMessage("Couldn't generate invite, please try again.");
+      return;
+    }
+    const data = await res.json();
+    setMessage(data.message);
+    setLoading(false);
+  };
+
+  const copyInvite = async () => {
+    if (!message) return;
+    try {
+      await navigator.clipboard.writeText(message);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // ignore
+    }
+  };
+
+  return (
+    <div className="border rounded p-4 space-y-2">
+      <button
+        onClick={generateInvite}
+        disabled={loading}
+        className="bg-blue-600 text-white px-4 py-2 rounded disabled:opacity-50"
+      >
+        {loading ? "Generating..." : "Generate Invite"}
+      </button>
+      {message && (
+        <div className="space-y-2">
+          <p className="whitespace-pre-line">{message}</p>
+          <button
+            onClick={copyInvite}
+            className="text-sm text-blue-600 underline"
+          >
+            {copied ? "Copied!" : "Copy"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement invitation API and UI with `/invite` page
- improve RSVP UX by preventing non-onboarded users and showing RSVPed state
- document features in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685857c3a9288328b6161510b1ecd0aa