### PR TITLE
Add particle background to home page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,13 @@
 import ChatWindow from '@/components/ChatWindow';
+import BackgroundParticles from '@/components/BackgroundParticles';
 
 export default function Home() {
   return (
-    <div className="flex justify-center relative z-10">
-      <ChatWindow />
+    <div className="relative">
+      <BackgroundParticles />
+      <div className="flex justify-center relative z-10">
+        <ChatWindow />
+      </div>
     </div>
   );
 }

--- a/components/BackgroundParticles.tsx
+++ b/components/BackgroundParticles.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import Particles from "react-tsparticles";
+import type { Engine } from "@tsparticles/engine";
+import { loadFull } from "tsparticles";
+import { useCallback } from "react";
+
+export default function BackgroundParticles() {
+  const particlesInit = useCallback(async (engine: Engine) => {
+    await loadFull(engine);
+  }, []);
+
+  return (
+    <Particles
+      id="background-particles"
+      init={particlesInit}
+      options={{
+        fullScreen: { enable: true, zIndex: 0 },
+        background: { color: "transparent" },
+        particles: {
+          number: { value: 60, density: { enable: true, area: 800 } },
+          color: { value: "#ff69b4" },
+          links: {
+            enable: true,
+            color: "#ff69b4",
+            distance: 150,
+            opacity: 0.5,
+          },
+          move: { enable: true, speed: 1 },
+          size: { value: { min: 1, max: 3 } },
+          opacity: { value: 0.5 },
+        },
+      }}
+    />
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.49.9",
+        "@tsparticles/engine": "3.8.1",
         "ai": "^4.3.16",
         "clsx": "^2.1.1",
         "lucide-react": "^0.511.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.49.9",
+    "@tsparticles/engine": "3.8.1",
     "ai": "^4.3.16",
     "clsx": "^2.1.1",
     "lucide-react": "^0.511.0",


### PR DESCRIPTION
## Summary
- add `BackgroundParticles` component using `react-tsparticles`
- show animated particles on the home page behind the chat window
- include `@tsparticles/engine` dependency and update import to fix build error

## Testing
- `npm run lint`
- `npm run build` *(fails to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_686a90c939a48328a35917ad7ee10c81