### PR TITLE
Fix Particles TypeScript error

### DIFF
--- a/components/BackgroundParticles.tsx
+++ b/components/BackgroundParticles.tsx
@@ -51,7 +51,7 @@ export default function BackgroundParticles() {
           number: {
             density: {
               enable: true,
-              area: 800
+              value_area: 800
             },
             value: 60
           },


### PR DESCRIPTION
## Summary
- update BackgroundParticles.tsx to use `value_area` for particle density

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts from fonts.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_686bc628cfd48328b0cb4eb7b04549b4