### PR TITLE
Fix particle type mismatch

### DIFF
--- a/components/BackgroundParticles.tsx
+++ b/components/BackgroundParticles.tsx
@@ -49,10 +49,6 @@ export default function BackgroundParticles() {
             straight: false
           },
           number: {
-            density: {
-              enable: true,
-              area: 800
-            },
             value: 60
           },
           opacity: {


### PR DESCRIPTION
## Summary
- remove obsolete density option in `BackgroundParticles`

## Testing
- `npm run build` *(fails: Failed to fetch fonts)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686bc78ac6b88328bdc703ce25bd2cce