### PR TITLE
Update layout nav styling with Orbitron font

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -12,6 +12,7 @@
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
+  --font-space: var(--font-orbitron);
 }
 
 @media (prefers-color-scheme: dark) {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist, Geist_Mono, Orbitron } from "next/font/google";
 import Link from 'next/link';
 import "./globals.css";
 
@@ -10,6 +10,11 @@ const geistSans = Geist({
 
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
+  subsets: ["latin"],
+});
+
+const orbitron = Orbitron({
+  variable: "--font-orbitron",
   subsets: ["latin"],
 });
 
@@ -29,15 +34,30 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable} flex flex-col min-h-screen antialiased relative`}>
+    <html lang="en" className={`${orbitron.variable} ${geistSans.variable} ${geistMono.variable}`}> 
+      <body className="flex flex-col min-h-screen antialiased relative">
         <header className="bg-white shadow">
           <div className="container mx-auto px-4 py-4 flex flex-col md:flex-row justify-between md:items-center">
             <h1 className="text-2xl font-bold text-pink-600 text-center md:text-left">Gay-I Club Concierge</h1>
             <nav className="mt-2 md:mt-0 flex flex-col md:flex-row space-y-2 md:space-y-0 md:space-x-4 text-center">
-              <Link href="/" className="text-sm">Home</Link>
-              <Link href="/events" className="text-sm">Events</Link>
-              <Link href="/invite" className="text-sm">Invite</Link>
+              <Link
+                href="/"
+                className="text-sm font-space px-3 py-2 rounded-md backdrop-blur-sm bg-white/5 border border-cyan-500 text-cyan-500 transition-transform hover:scale-105 hover:shadow-[0_0_20px_rgba(34,211,238,0.6)]"
+              >
+                Home
+              </Link>
+              <Link
+                href="/events"
+                className="text-sm font-space px-3 py-2 rounded-md backdrop-blur-sm bg-white/5 border border-cyan-500 text-cyan-500 transition-transform hover:scale-105 hover:shadow-[0_0_20px_rgba(34,211,238,0.6)]"
+              >
+                Events
+              </Link>
+              <Link
+                href="/invite"
+                className="text-sm font-space px-3 py-2 rounded-md backdrop-blur-sm bg-white/5 border border-cyan-500 text-cyan-500 transition-transform hover:scale-105 hover:shadow-[0_0_20px_rgba(34,211,238,0.6)]"
+              >
+                Invite
+              </Link>
             </nav>
           </div>
         </header>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,7 +6,11 @@ module.exports = {
     './components/**/*.{js,ts,jsx,tsx}',
   ],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        space: ['var(--font-orbitron)', 'sans-serif'],
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- add space-themed Orbitron font and expose via `--font-orbitron`
- enable `font-space` Tailwind class
- style navigation buttons with glassmorphism and neon glow

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f27944d948328a57afa8e8ee1e765