### PR TITLE
Apply particles globally

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -167,3 +167,20 @@ body {
 .animate-fade-in {
   animation: fade-in 0.2s ease-out;
 }
+
+/* Particle background positioning */
+.particles-bg {
+  position: fixed !important;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -1;
+}
+
+header,
+main,
+footer {
+  position: relative;
+  z-index: 10;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Inter, Orbitron } from "next/font/google";
 import { InteractiveNavButton } from '@/components/InteractiveNavButton'
+import BackgroundParticles from '@/components/BackgroundParticles'
 import "./globals.css";
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
@@ -28,7 +29,8 @@ export default function RootLayout({
   return (
     <html lang="en" className={`${inter.className} ${orbitron.variable}`}>
       <body className="flex flex-col min-h-screen antialiased relative">
-        <header className="bg-white shadow">
+        <BackgroundParticles />
+        <header className="bg-white shadow relative z-10">
           <div className="container mx-auto px-4 py-4 flex flex-col md:flex-row justify-between md:items-center">
             <h1 className="text-2xl font-bold text-pink-600 text-center md:text-left">Gay-I Club Concierge</h1>
             <nav className="flex items-center space-x-4 font-orbitron relative z-10">
@@ -44,8 +46,8 @@ export default function RootLayout({
             </nav>
           </div>
         </header>
-        <main className="container mx-auto px-4 py-8 flex-1">{children}</main>
-        <footer className="bg-gray-100">
+        <main className="container mx-auto px-4 py-8 flex-1 relative z-10">{children}</main>
+        <footer className="bg-gray-100 relative z-10">
           <div className="container mx-auto px-4 py-4 text-center text-sm text-gray-500">
             © {new Date().getFullYear()} Gay-I Club Concierge. All rights reserved.
           </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,13 +1,9 @@
 import ChatWindow from '@/components/ChatWindow';
-import BackgroundParticles from '@/components/BackgroundParticles';
 
 export default function Home() {
   return (
-    <div className="relative">
-      <BackgroundParticles />
-      <div className="flex justify-center relative z-10">
-        <ChatWindow />
-      </div>
+    <div className="flex justify-center">
+      <ChatWindow />
     </div>
   );
 }

--- a/components/BackgroundParticles.tsx
+++ b/components/BackgroundParticles.tsx
@@ -3,8 +3,13 @@
 import { useEffect, useState } from "react";
 import Particles, { initParticlesEngine } from "@tsparticles/react";
 import { loadSlim } from "@tsparticles/slim";
+import type { ISourceOptions } from "@tsparticles/engine";
 
-export default function BackgroundParticles() {
+interface BackgroundParticlesProps {
+  config?: ISourceOptions;
+}
+
+export default function BackgroundParticles({ config }: BackgroundParticlesProps) {
   const [init, setInit] = useState(false);
 
   useEffect(() => {
@@ -17,72 +22,75 @@ export default function BackgroundParticles() {
 
   if (!init) return null;
 
+  const defaultConfig = {
+    fullScreen: {
+      enable: true,
+      zIndex: -1,
+    },
+    background: {
+      color: { value: "transparent" },
+    },
+    fpsLimit: 60,
+    particles: {
+      color: { value: "#ff69b4" },
+      links: {
+        color: "#ff69b4",
+        distance: 150,
+        enable: true,
+        opacity: 0.5,
+        width: 1,
+      },
+      move: {
+        direction: "none",
+        enable: true,
+        outModes: {
+          default: "bounce",
+        },
+        random: false,
+        speed: 1,
+        straight: false,
+      },
+      number: {
+        value: 60,
+      },
+      opacity: {
+        value: 0.5,
+      },
+      shape: {
+        type: "circle",
+      },
+      size: {
+        value: { min: 1, max: 3 },
+      },
+    },
+    detectRetina: true,
+    responsive: [
+      {
+        maxWidth: 1024,
+        options: {
+          particles: {
+            number: { value: 40 },
+          },
+          fpsLimit: 45,
+        },
+      },
+      {
+        maxWidth: 768,
+        options: {
+          particles: {
+            number: { value: 25 },
+          },
+          fpsLimit: 30,
+        },
+      },
+    ],
+  };
+
   return (
     <Particles
       id="tsparticles"
-      options={{
-        fullScreen: {
-          enable: true,
-          zIndex: -1
-        },
-        background: {
-          color: { value: "transparent" }
-        },
-        fpsLimit: 60,
-        particles: {
-          color: { value: "#ff69b4" },
-          links: {
-            color: "#ff69b4",
-            distance: 150,
-            enable: true,
-            opacity: 0.5,
-            width: 1
-          },
-          move: {
-            direction: "none",
-            enable: true,
-            outModes: {
-              default: "bounce"
-            },
-            random: false,
-            speed: 1,
-            straight: false
-          },
-          number: {
-            value: 60
-          },
-          opacity: {
-            value: 0.5
-          },
-          shape: {
-            type: "circle"
-          },
-          size: {
-            value: { min: 1, max: 3 }
-          }
-        },
-        detectRetina: true,
-        responsive: [
-          {
-            maxWidth: 1024,
-            options: {
-              particles: {
-                number: { value: 40 }
-              },
-              fpsLimit: 45
-            }
-          },
-          {
-            maxWidth: 768,
-            options: {
-              particles: {
-                number: { value: 25 }
-              },
-              fpsLimit: 30
-            }
-          }
-        ]
-      }}
+      className="particles-bg"
+      options={config || defaultConfig}
     />
   );
 }


### PR DESCRIPTION
## Summary
- allow `BackgroundParticles` to accept custom config and apply styling
- add particle background to layout so all pages share it
- remove background from home page since layout handles it now
- ensure layered z-index via global CSS

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts because `fonts.googleapis.com` is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686fb814b33c832898b2d99bba76ddf4