### PR TITLE
Fix dark theme colors and add holographic effect

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,8 +3,8 @@
 @tailwind utilities;
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #000000;
+  --foreground: #ffffff;
 }
 
 @theme inline {
@@ -170,7 +170,11 @@ body {
 
 /* Holographic text style */
 .base-holographic {
-  @apply bg-gradient-to-r from-cyan-400 via-purple-500 to-red-500 bg-clip-text text-transparent filter drop-shadow-[0_0_30px_rgba(139,92,246,0.5)];
+  background: linear-gradient(90deg, #22d3ee, #3b82f6, #8b5cf6, #ec4899, #ef4444);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  filter: drop-shadow(0 0 30px rgba(139,92,246,0.5));
 }
 
 @keyframes glitch {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -48,8 +48,8 @@ export default function RootLayout({
           </div>
         </header>
         <main className="container mx-auto px-4 py-8 flex-1 relative z-10">{children}</main>
-        <footer className="bg-gray-100 relative z-10">
-          <div className="container mx-auto px-4 py-4 text-center text-sm text-gray-500">
+        <footer className="bg-gray-900/80 backdrop-blur-lg relative z-10">
+          <div className="container mx-auto px-4 py-4 text-center text-sm text-gray-400">
             © {new Date().getFullYear()} Gay-I Club Concierge. All rights reserved.
           </div>
         </footer>


### PR DESCRIPTION
## Summary
- set CSS variables for dark mode background/foreground
- add holographic gradient CSS
- tweak footer colors for better dark mode

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fe6d7f5d88328ac6a2b9584667862