### PR TITLE
Fix chat window width styling

### DIFF
--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -235,7 +235,7 @@ export default function ChatWindow() {
   // Render onboarding or chat UI
   if (!hasOnboarded) {
     return (
-      <div className="space-y-4">
+      <div className="w-full max-w-3xl mx-auto p-4 space-y-4">
         <div className="p-4 bg-white rounded-lg shadow">
           <p className="font-bold">
             {onboardingStep === 0 && `Welcome! What's your name?`}
@@ -317,12 +317,12 @@ export default function ChatWindow() {
     );
   }
   return (
-    <div className="space-y-4">
-      <div className="space-y-2 max-h-80 overflow-y-auto">
+    <div className="w-full max-w-3xl mx-auto p-4 space-y-4">
+      <div className="space-y-2 max-h-80 overflow-y-auto w-full">
         {messages.map((msg, i) => (
           <div
             key={i}
-            className={`p-2 rounded ${
+            className={`p-2 rounded max-w-full break-words ${
               msg.role === "user"
                 ? "bg-primary text-primary-foreground"
                 : "bg-muted"


### PR DESCRIPTION
## Summary
- ensure ChatWindow component and onboarding use centered width-limited container
- constrain message container width
- prevent messages from overflowing via `break-words`

## Testing
- `npx next lint` *(fails: Next not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6870577780ac8328ae61686321d2f8f0