### PR TITLE
Increase chat padding

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,7 @@ import ChatWindow from '@/components/ChatWindow';
 
 export default function Home() {
   return (
-    <div className="relative w-full max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div className="relative w-full max-w-6xl mx-auto">
       <div className="flex justify-center relative z-10">
         <ChatWindow />
       </div>

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -235,7 +235,7 @@ export default function ChatWindow() {
   // Render onboarding or chat UI
   if (!hasOnboarded) {
     return (
-      <div className="w-full max-w-3xl mx-auto p-4 space-y-4">
+      <div className="w-full max-w-3xl mx-auto px-8 py-4 space-y-4">
         <div className="p-4 bg-white rounded-lg shadow">
           <p className="font-bold">
             {onboardingStep === 0 && `Welcome! What's your name?`}
@@ -317,7 +317,7 @@ export default function ChatWindow() {
     );
   }
   return (
-    <div className="w-full max-w-3xl mx-auto p-4 space-y-4">
+    <div className="w-full max-w-3xl mx-auto px-8 py-4 space-y-4">
       <div className="space-y-2 max-h-80 overflow-y-auto w-full">
         {messages.map((msg, i) => (
           <div


### PR DESCRIPTION
## Summary
- remove horizontal padding from outer page wrapper so ChatWindow spacing isn't overridden

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6870ffd3e5608328b4d08e93472d6a9e